### PR TITLE
feat(webinar): add transfer status change

### DIFF
--- a/messageMapping.js
+++ b/messageMapping.js
@@ -6,7 +6,7 @@ module.exports = class MessageMapping {
   constructor() {
     this.mappedObject = {};
     this.mappedMessage = {};
-    this.meetingEvents = ["MeetingCreatedEvtMsg","MeetingDestroyedEvtMsg", "ScreenshareRtmpBroadcastStartedEvtMsg", "ScreenshareRtmpBroadcastStoppedEvtMsg", "SetCurrentPresentationEvtMsg", "RecordingStatusChangedEvtMsg"];
+    this.meetingEvents = ["MeetingCreatedEvtMsg","MeetingDestroyedEvtMsg", "ScreenshareRtmpBroadcastStartedEvtMsg", "ScreenshareRtmpBroadcastStoppedEvtMsg", "SetCurrentPresentationEvtMsg", "RecordingStatusChangedEvtMsg", "WebinarStatusChangedEvtMsg"];
     this.userEvents = ["UserJoinedMeetingEvtMsg","UserLeftMeetingEvtMsg","UserJoinedVoiceConfToClientEvtMsg","UserLeftVoiceConfToClientEvtMsg","PresenterAssignedEvtMsg", "PresenterUnassignedEvtMsg", "UserBroadcastCamStartedEvtMsg", "UserBroadcastCamStoppedEvtMsg", "UserEmojiChangedEvtMsg", "UserConnectedToTransferEvtMsg", "UserDisconnectedFromTransferEvtMsg"];
     this.chatEvents = ["SendPublicMessageEvtMsg","SendPrivateMessageEvtMsg"];
     this.rapEvents = ["PublishedRecordingSysMsg","UnpublishedRecordingSysMsg","DeletedRecordingSysMsg"];
@@ -347,6 +347,18 @@ module.exports = class MessageMapping {
     Logger.info("[MessageMapping] Mapped message:", this.mappedMessage);
   }
 
+  handleWebinarStatusChanged(message) {
+    const event = "meeting-transfer";
+    const { core } = message;
+    if (core && core.body) {
+      const { webinar } = core.body;
+      if (typeof webinar === 'boolean') {
+        if (webinar) return `${event}-enabled`;
+        return `${event}-disabled`;
+      }
+    }
+    return `${event}-unhandled`;
+  }
 
   mapInternalMessage(message) {
     let name;
@@ -360,6 +372,7 @@ module.exports = class MessageMapping {
       case "MeetingCreatedEvtMsg": return "meeting-created";
       case "MeetingDestroyedEvtMsg": return "meeting-ended";
       case "RecordingStatusChangedEvtMsg": return "meeting-recording-changed";
+      case "WebinarStatusChangedEvtMsg": return this.handleWebinarStatusChanged(message);
       case "ScreenshareRtmpBroadcastStartedEvtMsg": return "meeting-screenshare-started";
       case "ScreenshareRtmpBroadcastStoppedEvtMsg": return "meeting-screenshare-stopped";
       case "SetCurrentPresentationEvtMsg": return "meeting-presentation-changed";


### PR DESCRIPTION
The event `WebinarStatusChangedEvtMsg` is dispatched when the webinar-transfer
option is enabled or disabled. Add a new meeting event listener for this
event and handle it's message to identify if the property is being activated
or not.

`meeting-transfer-enabled`:
```
-------------------------------------
* Received: /callback?checksum=afdd20fcb140d949bfbef07bbbcc1f660dbe69dc
* Body: {
  event: '[{
    "data": {
      "type":"event",
      "id":"meeting-transfer-enabled",
      "attributes": {
        "meeting": {
          "internal-meeting-id":"b9a24da50af2a1510b1ce2fd3f6eb453fea5a6d2-1629293647551",
          "external-meeting-id":"random-8418397"
        }
      },
    "event": {
      "ts":1629293717867
    }
  }}]',
  timestamp: '1629293717867',
  domain: 'my.beautiful.domain'
}
-------------------------------------
```
`meeting-transfer-disabled`:
```
-------------------------------------
* Received: /callback?checksum=87994acfa9301fba609644b27f827edb357fd9aa
* Body: {
  event: '[{
    "data": {
      "type":"event",
      "id":"meeting-transfer-disabled",
      "attributes": {
        "meeting": {
          "internal-meeting-id":"b9a24da50af2a1510b1ce2fd3f6eb453fea5a6d2-1629293647551",
          "external-meeting-id":"random-8418397"
        }
      },
    "event": {
      "ts":1629293724561
    }
  }}]',
  timestamp: '1629293724563',
  domain: 'my.beautiful.domain'
}
-------------------------------------
```