### PR TITLE
feat: handle post_events_[started|ended]

### DIFF
--- a/src/process/event.js
+++ b/src/process/event.js
@@ -51,6 +51,8 @@ export default class WebhooksEvent {
     "rap-publish-ended",
     "rap-post-publish-started",
     "rap-post-publish-ended",
+    "rap-post-events-started",
+    "rap-post-events-ended",
     "poll-started",
     "poll-responded",
   ];
@@ -109,6 +111,8 @@ export default class WebhooksEvent {
       "publish_ended",
       "post_publish_started",
       "post_publish_ended",
+      "post_events_started",
+      "post_events_ended",
       "published",
       "unpublished",
       "deleted",
@@ -547,6 +551,10 @@ export default class WebhooksEvent {
         "download": data.download
       }
     }
+
+    if (this.outputEvent.data.id === "rap-post-events-ended" && data.data) {
+      this.outputEvent.data.attributes.data = data.data;
+    }
   }
 
   handleRecordingStatusChanged(message) {
@@ -700,6 +708,8 @@ export default class WebhooksEvent {
       case "deleted": return "rap-deleted";
       case "post_publish_started": return "rap-post-publish-started";
       case "post_publish_ended": return "rap-post-publish-ended";
+      case "post_events_started": return "rap-post-events-started";
+      case "post_events_ended": return "rap-post-events-ended";
     } })();
 
     return mappedMsg;

--- a/test/webhooks/helpers.js
+++ b/test/webhooks/helpers.js
@@ -202,5 +202,35 @@ helpers.rawMessageMeetingCreated = {
     }
   }
 };
+helpers.rawMessagePostEventsEnded = {
+  header: {
+    timestamp: 559978388,
+    name: 'post_events_ended',
+    current_time: 1784515407,
+    version: '0.0.1'
+  },
+  payload: {
+    success: true,
+    step_time: 1547,
+    data: {
+      activities: [{
+        name: 'Users Activities',
+        key: '1c33ac51/a77f2e54/964e58ce-1784515372853/activities.txt'
+      }],
+      chat: [{
+        name: 'Public Chat',
+        key: '1c33ac51/a77f2e54/964e58ce-1784515372853/chat.txt'
+      }],
+      presentations: [{
+        name: 'default-worka.pdf',
+        key: '1c33ac51/a77f2e54/964e58ce-1784515372853/presentations/fc9daf3e-1784515372964.pdf'
+      }]
+    },
+    workflow: 'post_events_mconf_data',
+    record_id: '964e58ce4788a1a3edd79c74417387abcf2edf58-1784515372853',
+    meeting_id: '964e58ce4788a1a3edd79c74417387abcf2edf58-1784515372853',
+    external_meeting_id: 'a77f2e5495fb613ec3fe8d86f933f523d73115aaf4c72653341a198f9bafc77a'
+  }
+};
 
 export default helpers;

--- a/test/webhooks/index.js
+++ b/test/webhooks/index.js
@@ -201,6 +201,50 @@ export default function suite({
     })
   });
 
+  describe('/POST mapped rap-post-events-ended message', () => {
+    let catcher;
+
+    before((done) => {
+      catcher = new HooksPostCatcher(WH_CONFIG.permanentURLs[1].url);
+      const hooks = Hook.get().getAllGlobalHooks();
+      const hook = hooks[0];
+      Helpers.flushredis(hook);
+      catcher.start().then(() => {
+        done();
+      });
+    });
+
+    after((done) => {
+      const hooks = Hook.get().getAllGlobalHooks();
+      const hook = hooks[0];
+      Helpers.flushredis(hook);
+      catcher.stop();
+      done();
+    })
+
+    it('should post mapped rap-post-events-ended message', (done) => {
+      catcher.once('callback', (body) => {
+        try {
+          const parsed = JSON.parse(body?.event);
+          const { id, attributes } = parsed[0].data || {};
+          if (id === 'rap-post-events-ended'
+            && attributes['record-id'] === Helpers.rawMessagePostEventsEnded.payload.record_id
+            && attributes.success === true
+            && attributes.workflow === 'post_events_mconf_data'
+            && attributes.data?.activities?.length > 0) {
+            done();
+          } else {
+            done(new Error("incorrectly mapped rap-post-events-ended message: " + body?.event));
+          }
+        } catch (error) {
+          done(error);
+        }
+      });
+
+      redisClient.publish(testChannel, JSON.stringify(Helpers.rawMessagePostEventsEnded));
+    })
+  });
+
   describe('/POST raw message', () => {
     let catcher;
 


### PR DESCRIPTION
Handle `post_events_started`/`post_events_ended` rap events, mapped to `rap-post-events-started`/`rap-post-events-ended` (artifact keys included in `data`).